### PR TITLE
Add ability to optionally select a specific test to run.

### DIFF
--- a/MxUnitRunnerBrowserCommand.py
+++ b/MxUnitRunnerBrowserCommand.py
@@ -19,8 +19,7 @@ class MxUnitRunnerBrowserCommand(sublime_plugin.TextCommand):
 		return view.settings().get("mxunit-runner")
 
 	def convertToTestURL(self, fileToOpen, basePath, baseUrl, testMethod, additionalUrlParameters):
-		urlPath = fileToOpen.replace(basePath, baseUrl)
-		urlPath = re.sub(r"\\", "/", urlPath) + "?method=runtestremote&output=html" + additionalUrlParameters
+		urlPath = re.sub(r"\\", "/", fileToOpen.replace(basePath, baseUrl)) + "?method=runtestremote&output=html" + additionalUrlParameters
 
 		if len(testMethod) > 0:
 			urlPath += "&testMethod=" + testMethod

--- a/MxUnitRunnerBrowserCommand.py
+++ b/MxUnitRunnerBrowserCommand.py
@@ -32,10 +32,6 @@ class MxUnitRunnerBrowserCommand(sublime_plugin.TextCommand):
 	def run(self, edit):
 		print("MXUnit Runner plugin v{0}, Python {1}".format(PLUGIN_VERSION, self._pythonVersion))
 
-		selectedRegion = self.view.sel()
-		testMethod = self.view.substr(selectedRegion[0])
-
-
 		projectSettings = self.getProjectSettings(self.view)
 		fileToOpen = self.view.file_name()
 
@@ -44,6 +40,11 @@ class MxUnitRunnerBrowserCommand(sublime_plugin.TextCommand):
 			return
 
 		additionalUrlParameters = projectSettings["additionalUrlParameters"] if "additionalUrlParameters" in projectSettings else ""
+
+		# determine if the user has selected a specific method to run instead of running all tests in the file
+		selectedRegion = self.view.sel()
+		testMethod = self.view.substr(selectedRegion[0])
+
 		urlPath = self.convertToTestURL(fileToOpen, projectSettings["testsDirectory"], projectSettings["urlPrefix"], testMethod, additionalUrlParameters)
 
 		#

--- a/MxUnitRunnerBrowserCommand.py
+++ b/MxUnitRunnerBrowserCommand.py
@@ -20,12 +20,11 @@ class MxUnitRunnerBrowserCommand(sublime_plugin.TextCommand):
 
 	def convertToTestURL(self, fileToOpen, basePath, baseUrl, testMethod, additionalUrlParameters):
 		urlPath = fileToOpen.replace(basePath, baseUrl)
-		urlPath = re.sub(r"\\", "/", urlPath) + "?method=runtestremote&output=html"
+		urlPath = re.sub(r"\\", "/", urlPath) + "?method=runtestremote&output=html" + additionalUrlParameters
 
 		if len(testMethod) > 0:
 			urlPath += "&testMethod=" + testMethod
 
-		urlPath += additionalUrlParameters
 		return urlPath
 
 	def run(self, edit):

--- a/MxUnitRunnerBrowserCommand.py
+++ b/MxUnitRunnerBrowserCommand.py
@@ -18,11 +18,23 @@ class MxUnitRunnerBrowserCommand(sublime_plugin.TextCommand):
 	def getProjectSettings(self, view):
 		return view.settings().get("mxunit-runner")
 
-	def convertToTestURL(self, fileToOpen, basePath, baseUrl, additionalUrlParameters):
-		return re.sub(r"\\", "/", fileToOpen.replace(basePath, baseUrl)) + "?method=runtestremote&output=html&" + additionalUrlParameters
+	def convertToTestURL(self, fileToOpen, basePath, baseUrl, testMethod, additionalUrlParameters):
+		urlPath = fileToOpen.replace(basePath, baseUrl)
+		urlPath = re.sub(r"\\", "/", urlPath) + "?method=runtestremote&output=html"
+
+		#if a user selected a specific test method to run we should just run that one test instead of the entire file.
+		tmLen = len(testMethod)
+		if tmLen > 0:
+			urlPath += "&testMethod=" + testMethod
+		urlPath += additionalUrlParameters
+		return urlPath
 
 	def run(self, edit):
 		print("MXUnit Runner plugin v{0}, Python {1}".format(PLUGIN_VERSION, self._pythonVersion))
+
+		selectedRegion = self.view.sel()
+		testMethod = self.view.substr(selectedRegion[0])
+
 
 		projectSettings = self.getProjectSettings(self.view)
 		fileToOpen = self.view.file_name()
@@ -32,7 +44,7 @@ class MxUnitRunnerBrowserCommand(sublime_plugin.TextCommand):
 			return
 
 		additionalUrlParameters = projectSettings["additionalUrlParameters"] if "additionalUrlParameters" in projectSettings else ""
-		urlPath = self.convertToTestURL(fileToOpen, projectSettings["testsDirectory"], projectSettings["urlPrefix"], additionalUrlParameters)
+		urlPath = self.convertToTestURL(fileToOpen, projectSettings["testsDirectory"], projectSettings["urlPrefix"], testMethod, additionalUrlParameters)
 
 		#
 		# Run tests in default web browser

--- a/MxUnitRunnerBrowserCommand.py
+++ b/MxUnitRunnerBrowserCommand.py
@@ -22,10 +22,9 @@ class MxUnitRunnerBrowserCommand(sublime_plugin.TextCommand):
 		urlPath = fileToOpen.replace(basePath, baseUrl)
 		urlPath = re.sub(r"\\", "/", urlPath) + "?method=runtestremote&output=html"
 
-		#if a user selected a specific test method to run we should just run that one test instead of the entire file.
-		tmLen = len(testMethod)
-		if tmLen > 0:
+		if len(testMethod) > 0:
 			urlPath += "&testMethod=" + testMethod
+
 		urlPath += additionalUrlParameters
 		return urlPath
 


### PR DESCRIPTION
I wanted to provide a way to only run a specific test in a test file that didn't break how the plugin already worked.  So now, if you have highlighted some text then you use the command to run mxunit tests in the browser it will append the url argument &testMethod=foo where foo is the highlighted text.

This change works with both the command pallet and the context menu.  If no text is highlighted the standard behavior continues (all tests in the open file are executed).
