### PR TITLE
updated readme to include installation instructions

### DIFF
--- a/MxUnitRunnerBrowserCommand.py
+++ b/MxUnitRunnerBrowserCommand.py
@@ -19,22 +19,15 @@ class MxUnitRunnerBrowserCommand(sublime_plugin.TextCommand):
 		return view.settings().get("mxunit-runner")
 
 	def convertToTestURL(self, fileToOpen, basePath, baseUrl, testMethod, additionalUrlParameters):
-		urlPath = fileToOpen.replace(basePath, baseUrl)
-		urlPath = re.sub(r"\\", "/", urlPath) + "?method=runtestremote&output=html"
+		urlPath = re.sub(r"\\", "/", fileToOpen.replace(basePath, baseUrl)) + "?method=runtestremote&output=html" + additionalUrlParameters
 
-		#if a user selected a specific test method to run we should just run that one test instead of the entire file.
-		tmLen = len(testMethod)
-		if tmLen > 0:
+		if len(testMethod) > 0:
 			urlPath += "&testMethod=" + testMethod
-		urlPath += additionalUrlParameters
+
 		return urlPath
 
 	def run(self, edit):
 		print("MXUnit Runner plugin v{0}, Python {1}".format(PLUGIN_VERSION, self._pythonVersion))
-
-		selectedRegion = self.view.sel()
-		testMethod = self.view.substr(selectedRegion[0])
-
 
 		projectSettings = self.getProjectSettings(self.view)
 		fileToOpen = self.view.file_name()
@@ -44,6 +37,11 @@ class MxUnitRunnerBrowserCommand(sublime_plugin.TextCommand):
 			return
 
 		additionalUrlParameters = projectSettings["additionalUrlParameters"] if "additionalUrlParameters" in projectSettings else ""
+
+		# determine if the user has selected a specific method to run instead of running all tests in the file
+		selectedRegion = self.view.sel()
+		testMethod = self.view.substr(selectedRegion[0])
+
 		urlPath = self.convertToTestURL(fileToOpen, projectSettings["testsDirectory"], projectSettings["urlPrefix"], testMethod, additionalUrlParameters)
 
 		#

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 Sublime Text MXUnit Test Runner
 ===============================
 
-MXUnit Test Runner is a Sublime Text 2 and 3 plugin for running all unit tests for the current open test component. When you have a test CFC open and are exercising all that TDD goodness, you can simply right-click and select *Run MXUnit Tests in the Browser*. This command is also available in the Sublime command palette. 
+MXUnit Test Runner is a Sublime Text 2 and 3 plugin for running all unit tests for the current open test component. When you have a test CFC open and are exercising all that TDD goodness, you can simply right-click and select *Run MXUnit Tests in the Browser*. This command is also available in the Sublime command palette.
+
+## Installation
+To install this plugin you need to use git to clone the repository into your sublime packages directory.  The easiest way to find that directory is to go into sublime and select  Prefences -> Browse Packages.  That will open the directory where your packages are installed.  Then go to your shell (cmd, terminal, etc) and git clone this repository.
+Once the repo is downloaded this plugin will be automatically activated.  However, you'll need to configure things on a per-project level to get it to actually work for you.  If you aren't currently using the Sublime Project feature for the project you're working on simply select the Project Menu then "Save Project As".  Once you've saved your project you'll get two new files {projectname}.sublime-project and {project-name}.sublime-workspace.
 
 ## Configuration
 To use this plugin you must make use of Sublime's **Project** feature. Each project has a project file where you can setup things like what folders are in your project, as well as settings. MXUnit Test Runner makes use of the project file and expects you to have the following information configured.
@@ -18,7 +22,7 @@ The settings demonstrated above must go into a **settings** key in your project 
 
 ```javascript
 {
-    "folders": 
+    "folders":
     [
         {
             "follow_symlinks": true,


### PR DESCRIPTION
added some basic installation instructions letting people know they have to clone the repo and where to clone it to.  I don't know to get the plugin included in the package manager install process but that would probably be a better solution in the long term.

I'm not sure what the conflict is; I just added a paragraph of text.
