### PR TITLE
Change keymap to ctrl+shift+X

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,3 +1,3 @@
 [
-    { "keys": ["ctrl+shift+m+x"], "command": "mx_unit_runner_browser"}
+    { "keys": ["ctrl+shift+x"], "command": "mx_unit_runner_browser"}
 ]


### PR DESCRIPTION
the default sublime keymap of ctrl+shift+m was conflicting with ctrl+shift+m+x when running unit tests in cfscript.  the ctrl+shift+m keymap
selects all contents of the current parentheses and was being executed before the unit test runner. This resulted in the unit test not being
run and an error popping up in the browser when trying to run the unit test.

Just using ctrl+shift+x works and doesnt conflict with any standard keymappings.

http://sublime-text-unofficial-documentation.readthedocs.org/en/latest/reference/keyboard_shortcuts_win.html
